### PR TITLE
Update to lts-15.11

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.9
+resolver: lts-15.11
 packages:
 - .
 extra-deps:


### PR DESCRIPTION
This is supposed to solve the problem, that `releaser` is marked as broken on the current `nixpkgs/haskell-updates` branch.

The only change seems to be a new verbosity parameter in a cabal call.

This bump is necessery to drop the dependency on regex-tdfa-text which
is marked as deprecated on hackage and since it is no longer maintained
also broken in nixpkgs.
