### PR TITLE
Disable automatic haddock upload on stack

### DIFF
--- a/releaser.cabal
+++ b/releaser.cabal
@@ -22,6 +22,8 @@ library
     default-extensions: OverloadedStrings
     build-depends:
         base >=4.7 && <5,
+        directory -any,
+        filepath -any,
         Cabal -any,
         regex-tdfa -any,
         process -any,

--- a/releaser/Main.hs
+++ b/releaser/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Releaser.Primitives
 import System.IO (hSetBuffering, stdout, stderr, BufferMode(..))
+import Control.Monad (when)
 
 main :: IO ()
 main = do
@@ -26,5 +27,7 @@ main = do
   cabalUpload tarball
 
   -- make haddocks and upload them
-  docsTarball <- cabalMakeHaddocks "."
-  cabalUploadDocs docsTarball
+  detectedBuildSystem <- detectBuildSystem "."
+  when (detectedBuildSystem == Cabal) $ do
+     docsTarball <- cabalMakeHaddocks "."
+     cabalUploadDocs docsTarball


### PR DESCRIPTION
While cabal has a "--haddocks-for-hackage" flag, stack does not.
This is an open issue since 2015.

See: https://github.com/commercialhaskell/stack/issues/737

It would probably be easy to implement this in releaser, but that is out of
scope for this commit.

This commit adds also a very rudimentary detectBuildSystem utility. It
might become useful in general.

This addresses the discussion from issue #10.