### PR TITLE
Switch to Cabal 3.6

### DIFF
--- a/releaser.cabal
+++ b/releaser.cabal
@@ -22,7 +22,8 @@ library
     default-extensions: OverloadedStrings
     build-depends:
         base >=4.7 && <5,
-        Cabal -any,
+        bytestring,
+        Cabal >=3.6,
         regex-tdfa -any,
         process -any,
         pretty-terminal -any,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.11
+resolver: lts-21.7
 packages:
 - .
 extra-deps:


### PR DESCRIPTION
This supports and requires Cabal 3.6, based on #18 
Builds with Cabal 3.8.1 from the snapshot, and with Nixpkgs unstable.

```
nix-repl> :lf nixpkgs/nixos-unstable
nix-repl> :b legacyPackages.x86_64-linux.haskellPackages.callCabal2nix "releaser" ./. {}
```